### PR TITLE
Fix path to config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 			"id": "coffee",
 			"aliases": ["CJSX", "coffee"],
 			"extensions": [".cjsx"],
-			"configuration": "./coffee.configuration.json"
+			"configuration": "./cjsx.configuration.json"
 		}],
 		"grammars": [{
 			"language": "coffee",


### PR DESCRIPTION
Hi,

This fixes the issue when you couldn't use `comment` command, because the editor didn't have the correct path to the config file.